### PR TITLE
Update setupProxy.js

### DIFF
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,4 +1,4 @@
-const { createProxyMiddleware } = require("http-proxy-middleware");
+const createProxyMiddleware = require("http-proxy-middleware");
 
 // This proxy redirects requests to /api endpoints to
 // the Express server running on port 3001.


### PR DESCRIPTION
The destructuring import causes an error. Removing the curly brackets fixes it.

createProxyMiddleware is not a function
[0] npm ERR! code 1
[0] npm ERR! path /Users/bleb/DEV/play/TWITTER/real-time-tweet-streamer
[0] npm ERR! command failed

<img width="939" alt="Screen Shot 2020-11-24 at 7 30 42 PM" src="https://user-images.githubusercontent.com/54607186/100179784-8fa1a780-2e8b-11eb-9c87-8172fd28cc5f.png">


solution found here : https://www.reddit.com/r/reactjs/comments/jzoo3y/createproxymiddleware_is_not_a_function_how_can_i/
